### PR TITLE
Update README.md with fileb for aws cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ replace the execution role with an existing role in your account!
 ```shell
 $ aws lambda create-function --function-name OCamlTest \
   --handler doesnt.matter \
-  --zip-file file://./ocaml.zip \
+  --zip-file fileb://./ocaml.zip \
   --runtime provided \
   --role arn:aws:iam::XXXXXXXXXXXXX:role/your_lambda_execution_role \
   --tracing-config Mode=Active


### PR DESCRIPTION
When I tested with my aws cli version it failed with the "file" argument, but worked with the "fileb" argument.